### PR TITLE
Add `always_false` metafunction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Copyright 2023 Adam Morrissett
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This project uses PROJECT_IS_TOP_LEVEL and C_STANDARD 17, both of which were
+# added in CMake 3.21.
+cmake_minimum_required(VERSION 3.21)
+project(libcarma)
+enable_testing()
+
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+
+include(options.cmake)
+include(dependencies.cmake)
+
+# CARMA targets C++17 and C17
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_C_STANDARD 17)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ${libcarma_EXPORT_COMPILE_COMMANDS})
+
+# This prevents colcon from trying to build CMake build artifacts when the
+# project is incorporated into a ROS 2 workspace.
+file(TOUCH ${PROJECT_BINARY_DIR}/COLCON_IGNORE)
+
+if(libcarma_metaprogramming_BUILD_LIBRARY)
+  add_subdirectory(metaprogramming)
+endif()

--- a/metaprogramming/CMakeLists.txt
+++ b/metaprogramming/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Copyright 2023 Adam Morrissett
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(options.cmake)
+
+add_library(libcarma_metaprogramming INTERFACE)
+add_library(libcarma::metaprogramming ALIAS libcarma_metaprogramming)
+
+target_include_directories(libcarma_metaprogramming
+  INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+)
+
+libcarma_target_remove_library_prefix(libcarma_metaprogramming)
+
+if(libcarma_metaprogramming_BUILD_TESTS)
+  add_subdirectory(test)
+endif()
+
+if(libcarma_metaprogramming_BUILD_INSTALL)
+  libcarma_target_set_install_rules(libcarma_metaprogramming)
+endif()

--- a/metaprogramming/cmake/libcarma_metaprogrammingConfig.cmake
+++ b/metaprogramming/cmake/libcarma_metaprogrammingConfig.cmake
@@ -1,1 +1,15 @@
+# Copyright 2023 Adam Morrissett
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 include(${CMAKE_CURRENT_LIST_DIR}/libcarma/libcarma_metaprogrammingTargets.cmake)

--- a/metaprogramming/cmake/libcarma_metaprogrammingConfig.cmake
+++ b/metaprogramming/cmake/libcarma_metaprogrammingConfig.cmake
@@ -1,0 +1,1 @@
+include(${CMAKE_CURRENT_LIST_DIR}/libcarma/libcarma_metaprogrammingTargets.cmake)

--- a/metaprogramming/include/libcarma/metaprogramming/always_false.hpp
+++ b/metaprogramming/include/libcarma/metaprogramming/always_false.hpp
@@ -1,0 +1,36 @@
+// Copyright 2023 Adam Morrissett
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBCARMA_METAPROGRAMMING_ALWAYS_FALSE_HPP_
+#define LIBCARMA_METAPROGRAMMING_ALWAYS_FALSE_HPP_
+
+#include <type_traits>
+
+namespace carma::metaprogramming
+{
+
+template <typename...>
+struct always_false : std::false_type
+{
+};
+
+template <typename... Ts>
+using always_false_t = typename always_false<Ts...>::type;
+
+template <typename... Ts>
+inline constexpr bool always_false_v = always_false<Ts...>::value;
+
+}  // namespace carma::metaprogramming
+
+#endif  // LIBCARMA_METAPROGRAMMING_ALWAYS_FALSE_HPP_

--- a/metaprogramming/options.cmake
+++ b/metaprogramming/options.cmake
@@ -1,0 +1,33 @@
+# Copyright 2023 Adam Morrissett
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+option(libcarma_metaprogramming_BUILD_TESTS
+  "Build CARMA Metaprogramming Library tests"
+  ${libcarma_BUILD_TESTS}
+)
+
+option(libcarma_metaprogramming_BUILD_INSTALL
+  "Build CARMA Metaprogramming Library CMake install targets"
+  ${libcarma_BUILD_INSTALL}
+)
+
+option(libcarma_metaprogramming_BUILD_DOCS
+  "Build CARMA Metaprogramming Library docs"
+  ${libcarma_BUILD_DOCS}
+)
+
+option(libcarma_metaprogramming_BUILD_PACKAGING
+  "Build CARMA Metaprogramming Library packaging artifacts"
+  ${libcarma_BUILD_PACKAGING}
+)

--- a/metaprogramming/test/CMakeLists.txt
+++ b/metaprogramming/test/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Copyright 2023 Adam Morrissett
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_library(libcarma_metaprogramming_unit_tests
+  test_always_false.cpp
+)
+
+target_link_libraries(libcarma_metaprogramming_unit_tests
+  PRIVATE
+    libcarma::metaprogramming
+)
+
+libcarma_set_target_compiler_warnings(libcarma_metaprogramming_unit_tests)

--- a/metaprogramming/test/test_always_false.cpp
+++ b/metaprogramming/test/test_always_false.cpp
@@ -1,0 +1,25 @@
+// Copyright 2023 Adam Morrissett
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <libcarma/metaprogramming/always_false.hpp>
+
+struct T
+{
+};
+
+static_assert(!carma::metaprogramming::always_false<T>::value);
+static_assert(!carma::metaprogramming::always_false_v<T>);
+
+static_assert(std::is_same_v<carma::metaprogramming::always_false<T>::type, std::false_type>);
+static_assert(std::is_same_v<carma::metaprogramming::always_false_t<T>, std::false_type>);

--- a/options.cmake
+++ b/options.cmake
@@ -1,0 +1,50 @@
+# Copyright 2023 Adam Morrissett
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Project-wide options
+option(libcarma_EXPORT_COMPILE_COMMANDS
+  "Export CARMA Library CMake compile commands"
+  ${PROJECT_IS_TOP_LEVEL}
+)
+
+option(libcarma_BUILD_LIBRARIES
+  "Build all CARMA Library libraries by default"
+  ${PROJECT_IS_TOP_LEVEL}
+)
+
+option(libcarma_BUILD_TESTS
+  "Build all CARMA Library tests by default"
+  ${PROJECT_IS_TOP_LEVEL}
+)
+
+option(libcarma_BUILD_INSTALL
+  "Build all CARMA Library CMake install targets by default"
+  ${PROJECT_IS_TOP_LEVEL}
+)
+
+option(libcarma_BUILD_DOCS
+  "Build all CARMA Library docs by default"
+  ${PROJECT_IS_TOP_LEVEL}
+)
+
+option(libcarma_BUILD_PACKAGING
+  "Build packaging artifacts for CARMA Library"
+  ${PROJECT_IS_TOP_LEVEL}
+)
+
+# Options to build individual libraries
+option(libcarma_metaprogramming_BUILD_LIBRARY
+  "Build CARMA Metaprogramming library"
+  ${libcarma_BUILD_LIBRARIES}
+)


### PR DESCRIPTION
This PR adds the `always_false` metafunction to facilitate `static_assert`s inside base class templates that should not be used. This addition has been tested with compile-time unit tests.

Closes #3 