### PR TITLE
Add SAE Common library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,5 +34,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ${libcarma_EXPORT_COMPILE_COMMANDS})
 file(TOUCH ${PROJECT_BINARY_DIR}/COLCON_IGNORE)
 
 if(libcarma_metaprogramming_BUILD_LIBRARY)
-  add_subdirectory(metaprogramming)
+  libcarma_add_to_build(metaprogramming)
+endif()
+
+if(libcarma_sae_common_BUILD_LIBRARY)
+  libcarma_add_to_build(sae_common)
 endif()

--- a/cmake/get_cpm.cmake
+++ b/cmake/get_cpm.cmake
@@ -1,0 +1,55 @@
+# MIT License
+#
+# Copyright (c) 2019-2022 Lars Melchior and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Reference: https://github.com/cpm-cmake/CPM.cmake/blob/master/cmake/get_cpm.cmake
+
+if(CPM_SOURCE_CACHE)
+  set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+  set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+else()
+  set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+endif()
+
+# Expand relative path. This is important if the provided path contains a tilde (~)
+get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
+
+function(download_cpm)
+  message(STATUS "Downloading CPM.cmake to ${CPM_DOWNLOAD_LOCATION}")
+  file(DOWNLOAD
+       https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+       ${CPM_DOWNLOAD_LOCATION}
+  )
+endfunction()
+
+if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
+  download_cpm()
+else()
+  # resume download if it previously failed
+  file(READ ${CPM_DOWNLOAD_LOCATION} check)
+  if("${check}" STREQUAL "")
+    download_cpm()
+  endif()
+  unset(check)
+endif()
+
+include(${CPM_DOWNLOAD_LOCATION})

--- a/cmake/libcarma_add_to_build.cmake
+++ b/cmake/libcarma_add_to_build.cmake
@@ -1,0 +1,56 @@
+# Copyright 2023 Adam Morrissett
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#[=======================================================================[.rst:
+libcarma_add_to_build
+---------------------
+
+This module defines a function to conditionally add a subdirectory to the build
+tree. Some CARMA Library libraries depend on others, but attempting to add
+their subdirectories to the build tree will cause configuration errors if their
+contained targets have already been added. Conditionally adding the
+subdirectory avoids this issue.
+
+.. command:: libcarma_add_to_build
+
+  Add subdirectory to build if its contained targets have not already been
+  added to the build tree:
+  functions::
+
+    libcarma_add_to_build(target)
+
+  ``libcarma_add_to_build()`` adds the specified target's containing
+  subdirectory to the build tree if the target has not already been added. Note
+  that this function makes several implicit assumptions:
+
+    1. Argument ``target`` uses the naming convention ``libcarma::<library>``,
+       where ``<library>`` is the name of the CARMA Library library of interest.
+    2. The containing subdirectory of ``<library>`` uses the name ``<library>``.
+
+  The options are:
+
+  ``target``
+    Specifies the target name that will be checked.
+
+#]=======================================================================]
+
+function(libcarma_add_to_build target)
+
+  string(REPLACE "libcarma::" "" target_no_namespace ${target})
+
+  if(NOT TARGET ${target})
+    add_subdirectory(${target_no_namespace})
+  endif()
+
+endfunction()

--- a/cmake/libcarma_target_remove_export_name_prefix.cmake
+++ b/cmake/libcarma_target_remove_export_name_prefix.cmake
@@ -1,0 +1,53 @@
+# Copyright 2023 Adam Morrissett
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#[=======================================================================[.rst:
+libcarma_target_remove_export_name_prefix
+-----------------------------------------
+
+This module defines a function that removes the ``libcarma_`` prefix from a
+specified CARMA Library target's ``EXPORT_NAME``. By convention, CARMA Library
+names its CMake targets ``libcarma_<library>``, but this naming convention
+makes a user's CMake configuration look like ``libcarma::libcarma_<library>``
+when they want to link against that library.
+
+.. command:: libcarma_target_remove_export_name_prefix
+
+  Remove the ``libcarma_`` prefix from a target's ``EXPORT_NAME``:
+  functions::
+
+    libcarma_target_remove_export_name_prefix(target)
+
+  ``libcarma_target_remove_export_name_prefix()`` removes the ``libcarma_``
+  prefix from a specified target's ``EXPORT_NAME``.
+
+  The options are:
+
+  ``target``
+    Specifies the target that will have its ``EXPORT_NAME`` modified.
+
+#]=======================================================================]
+
+function(libcarma_target_remove_export_name_prefix target)
+
+  if(target MATCHES "libcarma_*")
+    string(REPLACE "libcarma_" "" target_no_prefix ${target})
+
+    set_target_properties(${target}
+      PROPERTIES
+        EXPORT_NAME ${target_no_prefix}
+    )
+  endif()
+
+endfunction()

--- a/cmake/libcarma_target_set_install_rules.cmake
+++ b/cmake/libcarma_target_set_install_rules.cmake
@@ -43,6 +43,9 @@ include(GNUInstallDirs)
 
 function(libcarma_target_set_install_rules target)
 
+  libcarma_target_remove_library_prefix(${target})
+  libcarma_target_remove_export_name_prefix(${target})
+
   install(TARGETS ${target}
     EXPORT ${target}Targets
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include(libcarma_add_to_build)
 include(libcarma_target_remove_library_prefix)
 include(libcarma_target_remove_export_name_prefix)
 include(libcarma_target_set_compiler_warnings)

--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -1,0 +1,30 @@
+# Copyright 2023 Adam Morrissett
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(libcarma_target_remove_library_prefix)
+include(libcarma_target_remove_export_name_prefix)
+include(libcarma_target_set_compiler_warnings)
+include(libcarma_target_set_install_rules)
+
+include(${PROJECT_SOURCE_DIR}/dependency_versions.cmake)
+
+# Install CMake dependency management script
+# The get_cpm.cmake script must be included before CPMAddPackage(...) calls
+set(CPM_DOWNLOAD_VERSION 0.38.2)
+include(get_cpm)
+
+# Tell CPM to search for locally-installed packages before using the source
+set(CPM_USE_LOCAL_PACKAGES ON)
+
+CPMAddPackage("gh:google/googletest#${libcarma_google_googletest_DEP_VERSION}")

--- a/dependency_versions.cmake
+++ b/dependency_versions.cmake
@@ -1,0 +1,27 @@
+# Copyright 2023 Adam Morrissett
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file contains the library versions used by various CARMA Library
+# libaries. Having libraries be self-contained is one of CARMA Library's goals,
+# but having each library responsible for declaring its own dependencies cna
+# lead to libraries using different versions of common dependencies. The
+# opposite end, having a centralized dependencies file, would require us to
+# use some complicated logic to determine when we should fetch certain
+# dependencies. As a compromise, we decided to let each library declare its
+# own dependencies, but only if they get the dependency version from a
+# centralized list. This allows us to easily manage dependency versions
+# through CARMA Library.
+
+set(libcarma_google_googletest_DEP_VERSION v1.14.0)
+set(libcarma_nholthaus_units_DEP_VERSION v2.3.3)

--- a/metaprogramming/CMakeLists.txt
+++ b/metaprogramming/CMakeLists.txt
@@ -22,8 +22,6 @@ target_include_directories(libcarma_metaprogramming
     $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
 )
 
-libcarma_target_remove_library_prefix(libcarma_metaprogramming)
-
 if(libcarma_metaprogramming_BUILD_TESTS)
   add_subdirectory(test)
 endif()

--- a/options.cmake
+++ b/options.cmake
@@ -48,3 +48,8 @@ option(libcarma_metaprogramming_BUILD_LIBRARY
   "Build CARMA Metaprogramming library"
   ${libcarma_BUILD_LIBRARIES}
 )
+
+option(libcarma_sae_common_BUILD_LIBRARY
+  "Build CARMA SAE Common library"
+  ${libcarma_BUILD_LIBRARIES}
+)

--- a/sae_common/CMakeLists.txt
+++ b/sae_common/CMakeLists.txt
@@ -1,0 +1,24 @@
+include(options.cmake)
+include(dependencies.cmake)
+
+add_library(libcarma_sae_common INTERFACE)
+add_library(libcarma::sae_common ALIAS libcarma_sae_common)
+
+target_include_directories(libcarma_sae_common
+  INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+)
+
+target_link_libraries(libcarma_sae_common
+  INTERFACE
+    libcarma::metaprogramming
+    units::units
+)
+
+if(libcarma_sae_common_BUILD_TESTS)
+  add_subdirectory(test)
+endif()
+
+if(libcarma_sae_common_BUILD_INSTALL)
+  libcarma_target_set_install_rules(libcarma_sae_common)
+endif()

--- a/sae_common/dependencies.cmake
+++ b/sae_common/dependencies.cmake
@@ -1,0 +1,1 @@
+libcarma_add_to_build(libcarma::metaprogramming)

--- a/sae_common/include/libcarma/sae_common/bad_data_element_access.hpp
+++ b/sae_common/include/libcarma/sae_common/bad_data_element_access.hpp
@@ -1,0 +1,30 @@
+#ifndef LIBCARMA_SAE_COMMON_BAD_DATA_ELEMENT_ACCESS_HPP_
+#define LIBCARMA_SAE_COMMON_BAD_DATA_ELEMENT_ACCESS_HPP_
+
+#include <exception>
+
+namespace carma::sae_common
+{
+
+class BadDataElementAccess : public std::exception
+{
+public:
+  BadDataElementAccess() = default;
+
+  BadDataElementAccess(const BadDataElementAccess &) = default;
+  auto operator=(const BadDataElementAccess &) -> BadDataElementAccess & = default;
+
+  BadDataElementAccess(BadDataElementAccess &&) = default;
+  auto operator=(BadDataElementAccess &&) -> BadDataElementAccess & = default;
+
+  ~BadDataElementAccess() override = default;
+
+  [[nodiscard]] auto what() const noexcept -> const char * override
+  {
+    return "bad data element access (data data_unavailable)";
+  }
+};
+
+}  // namespace carma::sae_common
+
+#endif  // LIBCARMA_SAE_COMMON_BAD_DATA_ELEMENT_ACCESS_HPP_

--- a/sae_common/include/libcarma/sae_common/data_element.hpp
+++ b/sae_common/include/libcarma/sae_common/data_element.hpp
@@ -1,0 +1,126 @@
+#ifndef LIBCARMA_SAE_COMMON_DATA_HPP_
+#define LIBCARMA_SAE_COMMON_DATA_HPP_
+
+#include <algorithm>
+#include <libcarma/metaprogramming/always_false.hpp>
+#include <optional>
+#include <type_traits>
+
+#include "libcarma/sae_common/bad_data_element_access.hpp"
+#include "libcarma/sae_common/data_unavailable.hpp"
+#include "libcarma/sae_common/units_extensions.hpp"
+
+namespace carma::sae_common
+{
+
+enum class Availability
+{
+  AlwaysAvailable,
+  SometimesAvailable
+};
+
+namespace detail
+{
+
+template <typename DataTraits, typename = void>
+struct storage_dispatcher_sfinae
+{
+  static_assert(
+    metaprogramming::always_false_v<DataTraits>,
+    "Could not find a class template specialization for specified `DataTraits` type");
+};
+
+template <typename DataTraits>
+struct storage_dispatcher_sfinae<
+  DataTraits, std::enable_if_t<DataTraits::availability == Availability::SometimesAvailable>>
+{
+  using type = std::optional<typename DataTraits::value_type>;
+};
+
+template <typename DataTraits>
+struct storage_dispatcher_sfinae<
+  DataTraits, std::enable_if_t<DataTraits::availability == Availability::AlwaysAvailable>>
+{
+  using type = typename DataTraits::value_type;
+};
+
+template <typename DataTraits>
+struct storage_dispatcher : storage_dispatcher_sfinae<DataTraits>
+{
+};
+
+template <typename DataTraits>
+using storage_dispatcher_t = typename storage_dispatcher<DataTraits>::type;
+
+}  // namespace detail
+
+template <typename DataTraits>
+class DataElement
+{
+  using value_type = typename DataTraits::value_type;
+
+public:
+  [[nodiscard]] static inline constexpr auto max() noexcept -> value_type
+  {
+    return DataTraits::max_value;
+  }
+  [[nodiscard]] static inline constexpr auto lower() noexcept -> value_type
+  {
+    return DataTraits::lower_value;
+  }
+
+  constexpr explicit DataElement() = default;
+  constexpr explicit DataElement(const value_type & value) { this->operator=(value); }
+
+  template <
+    typename DT = DataTraits,
+    std::enable_if_t<DT::availability == Availability::SometimesAvailable, bool> = true>
+  constexpr explicit DataElement(sae_common::data_unavailable_t /* data_unavailable */)
+  : value_{std::nullopt}
+  {
+  }
+
+  constexpr inline auto operator=(const value_type & value) noexcept -> DataElement<DataTraits> &
+  {
+    value_ = std::clamp(value, lower(), max());
+    return *this;
+  }
+
+  template <
+    typename DT = DataTraits,
+    std::enable_if_t<DT::availability == Availability::SometimesAvailable, bool> = true>
+  constexpr inline auto operator=(sae_common::data_unavailable_t /* data_unavailable */) noexcept
+    -> DataElement<DataTraits> &
+  {
+    value_ = std::nullopt;
+    return *this;
+  }
+
+  template <
+    typename DT = DataTraits,
+    std::enable_if_t<DT::availability == Availability::SometimesAvailable, bool> = true>
+  [[nodiscard]] constexpr auto is_available() const noexcept -> bool
+  {
+    return value_.has_value();
+  }
+
+  [[nodiscard]] constexpr auto value() const
+  {
+    if constexpr (DataTraits::availability == Availability::SometimesAvailable) {
+      if (!value_.has_value()) {
+        throw BadDataElementAccess();
+      }
+
+      return value_.value();
+    } else {
+      return value_;
+    }
+  }
+
+private:
+  detail::storage_dispatcher_t<DataTraits> value_;
+};
+
+}  // namespace carma::sae_common
+
+#endif  // LIBCARMA_SAE_COMMON_DATA_HPP_

--- a/sae_common/include/libcarma/sae_common/data_unavailable.hpp
+++ b/sae_common/include/libcarma/sae_common/data_unavailable.hpp
@@ -1,0 +1,17 @@
+#ifndef LIBCARMA_SAE_COMMON_DATA_UNAVAILABLE_HPP_
+#define LIBCARMA_SAE_COMMON_DATA_UNAVAILABLE_HPP_
+
+namespace carma::sae_common
+{
+
+struct data_unavailable_t
+{
+  constexpr explicit data_unavailable_t(int /* unused */) {}
+};
+
+inline constexpr data_unavailable_t data_unavailable{0};
+
+} // namespace carma::sae_common
+
+
+#endif // LIBCARMA_SAE_COMMON_DATA_UNAVAILABLE_HPP_

--- a/sae_common/include/libcarma/sae_common/units_extensions.hpp
+++ b/sae_common/include/libcarma/sae_common/units_extensions.hpp
@@ -1,0 +1,25 @@
+#ifndef LIBCARMA_SAE_COMMON_UNITS_HPP_
+#define LIBCARMA_SAE_COMMON_UNITS_HPP_
+
+#include <units.h>
+
+namespace units
+{
+
+template <typename T>
+constexpr auto remove_units(const T & value) noexcept
+{
+  return units::unit_cast<typename T::underlying_type>(value);
+}
+
+UNIT_ADD(
+  angle, eighth_deci_degree, eighth_deci_degrees, eighth_deci_deg,
+  unit<std::ratio_multiply<std::ratio<1, 8>, std::deci>, degrees>);
+
+UNIT_ADD(
+  velocity, two_centi_meter_per_second, two_centi_meters_per_second, two_centi_mps,
+  unit<std::ratio_multiply<std::ratio<2, 1>, std::centi>, meters_per_second>);
+
+}  // namespace units
+
+#endif  // LIBCARMA_SAE_COMMON_UNITS_HPP_

--- a/sae_common/options.cmake
+++ b/sae_common/options.cmake
@@ -1,0 +1,33 @@
+# Copyright 2023 Adam Morrissett
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+option(libcarma_sae_common_BUILD_TESTS
+  "Build CARMA SAE Common Library tests"
+  ${libcarma_BUILD_TESTS}
+)
+
+option(libcarma_sae_common_BUILD_INSTALL
+  "Build CARMA SAE Common Library CMake install targets"
+  ${libcarma_BUILD_INSTALL}
+)
+
+option(libcarma_sae_common_BUILD_DOCS
+  "Build CARMA SAE Common Library docs"
+  ${libcarma_BUILD_DOCS}
+)
+
+option(libcarma_sae_common_BUILD_PACKAGING
+  "Build CARMA SAE Common Library packaging artifacts"
+  ${libcarma_BUILD_PACKAGING}
+)

--- a/sae_common/test/CMakeLists.txt
+++ b/sae_common/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(libcarma_sae_common_unit_tests
   test_bad_data_element_access.cpp
+  test_data_element.cpp
 )
 
 target_link_libraries(libcarma_sae_common_unit_tests

--- a/sae_common/test/CMakeLists.txt
+++ b/sae_common/test/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_executable(libcarma_sae_common_unit_tests
+  test_bad_data_element_access.cpp
+)
+
+target_link_libraries(libcarma_sae_common_unit_tests
+  PRIVATE
+    libcarma::sae_common
+    GTest::gtest_main
+)
+
+libcarma_target_set_compiler_warnings(libcarma_sae_common_unit_tests
+  PRIVATE
+  WARNINGS_AS_ERRORS
+)
+
+include(GoogleTest)
+gtest_discover_tests(libcarma_sae_common_unit_tests)

--- a/sae_common/test/test_bad_data_element_access.cpp
+++ b/sae_common/test/test_bad_data_element_access.cpp
@@ -1,0 +1,10 @@
+#include <gtest/gtest.h>
+
+#include <libcarma/sae_common/bad_data_element_access.hpp>
+
+TEST(BadDataElementAccess, What)
+{
+  const carma::sae_common::BadDataElementAccess exception;
+
+  EXPECT_EQ(exception.what(), "bad data element access (data data_unavailable)");
+}

--- a/sae_common/test/test_data_element.cpp
+++ b/sae_common/test/test_data_element.cpp
@@ -1,0 +1,118 @@
+#include <gtest/gtest.h>
+#include <units.h>
+
+#include <libcarma/sae_common/data_element.hpp>
+
+namespace
+{
+
+struct AlwaysAvailableTestTraits
+{
+  using value_type = units::length::meter_t;
+
+  static constexpr value_type max_value{200};
+  static constexpr value_type lower_value{-30};
+  static constexpr carma::sae_common::Availability availability{
+    carma::sae_common::Availability::AlwaysAvailable};
+};
+
+struct SometimesAvailableTestTraits
+{
+  using value_type = units::length::meter_t;
+
+  static constexpr value_type max_value{100};
+  static constexpr value_type lower_value{-40};
+  static constexpr carma::sae_common::Availability availability{
+    carma::sae_common::Availability::SometimesAvailable};
+};
+
+using AlwaysAvailableTestDataElement = carma::sae_common::DataElement<AlwaysAvailableTestTraits>;
+
+using SometimesAvailableTestDataElement =
+  carma::sae_common::DataElement<SometimesAvailableTestTraits>;
+
+}  // namespace
+
+TEST(AlwaysAvailableTestDataElement, Available)
+{
+  using namespace units::literals;
+
+  const AlwaysAvailableTestDataElement data_element{12.0_m};
+
+  // This checks almost-equality because of how the units library implements the operator overload
+  EXPECT_EQ(data_element.value(), 12.0_m);
+}
+
+TEST(AlwaysAvailableTestDataElement, ValueTooHigh)
+{
+  using namespace units::literals;
+
+  const AlwaysAvailableTestDataElement data_element{500_m};
+
+  EXPECT_DOUBLE_EQ(
+    units::unit_cast<double>(data_element.value()), units::unit_cast<double>(data_element.max()));
+}
+
+TEST(AlwaysAvailableTestDataElement, ValueTooLow)
+{
+  using namespace units::literals;
+
+  const AlwaysAvailableTestDataElement data_element{-50_m};
+
+  EXPECT_DOUBLE_EQ(
+    units::unit_cast<double>(data_element.value()), units::unit_cast<double>(data_element.lower()));
+}
+
+TEST(SometimesAvailableTestDataElement, Available)
+{
+  using namespace units::literals;
+
+  const SometimesAvailableTestDataElement data_element{12.0_m};
+  ASSERT_TRUE(data_element.is_available());
+
+  EXPECT_DOUBLE_EQ(units::unit_cast<double>(data_element.value()), 12.0);
+}
+
+TEST(SometimesAvailableTestDataElement, DataUnavailable)
+{
+  {
+    const SometimesAvailableTestDataElement data_element;
+    EXPECT_FALSE(data_element.is_available());
+  }
+  {
+    const SometimesAvailableTestDataElement data_element{carma::sae_common::data_unavailable};
+    EXPECT_FALSE(data_element.is_available());
+  }
+  {
+    SometimesAvailableTestDataElement data_element;
+    data_element = carma::sae_common::data_unavailable;
+    EXPECT_FALSE(data_element.is_available());
+  }
+}
+
+TEST(SometimesAvailableTestDataElement, ValueTooHigh)
+{
+  using namespace units::literals;
+
+  const SometimesAvailableTestDataElement data_element{200_m};
+
+  EXPECT_DOUBLE_EQ(
+    units::unit_cast<double>(data_element.value()), units::unit_cast<double>(data_element.max()));
+}
+
+TEST(SometimesAvailableTestDataElement, ValueTooLow)
+{
+  using namespace units::literals;
+
+  const SometimesAvailableTestDataElement data_element{-40_m};
+
+  EXPECT_DOUBLE_EQ(
+    units::unit_cast<double>(data_element.value()), units::unit_cast<double>(data_element.lower()));
+}
+
+TEST(SometimesAvailableTestDataElement, BadDataElementAccess)
+{
+  const SometimesAvailableTestDataElement data_element;
+
+  EXPECT_THROW((void)data_element.value(), carma::sae_common::BadDataElementAccess);
+}


### PR DESCRIPTION
This PR adds the SAE Common library, which provides fundamental data types for use in specific SAE standards support libraries. This PR also cleans up the project-wide CMake modules.

Closes #13 