### PR TITLE
Fix CMake function call in metaprogramming

### DIFF
--- a/metaprogramming/test/CMakeLists.txt
+++ b/metaprogramming/test/CMakeLists.txt
@@ -21,4 +21,7 @@ target_link_libraries(libcarma_metaprogramming_unit_tests
     libcarma::metaprogramming
 )
 
-libcarma_set_target_compiler_warnings(libcarma_metaprogramming_unit_tests)
+libcarma_target_set_compiler_warnings(libcarma_metaprogramming_unit_tests
+  PRIVATE
+  WARNINGS_AS_ERRORS
+)


### PR DESCRIPTION
This PR fixes the CARMA Metaprogramming Library's `CMakeLists.txt` file for unit tests. It was previously trying to call a non-existent `libcarma` CMake function.

Closes #19 