### PR TITLE
Change `libcarma_add_to_build` to use `FetchContent`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,14 +33,28 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ${libcarma_EXPORT_COMPILE_COMMANDS})
 # project is incorporated into a ROS 2 workspace.
 file(TOUCH ${PROJECT_BINARY_DIR}/COLCON_IGNORE)
 
+include(FetchContent)
+
 if(libcarma_metaprogramming_BUILD_LIBRARY)
-  libcarma_add_to_build(metaprogramming)
+  FetchContent_Declare(libcarma_metaprogramming
+    SOURCE_DIR ${PROJECT_SOURCE_DIR}/metaprogramming
+  )
+
+  FetchContent_MakeAvailable(libcarma_metaprogramming)
 endif()
 
 if(libcarma_sae_common_BUILD_LIBRARY)
-  libcarma_add_to_build(sae_common)
+  FetchContent_Declare(libcarma_sae_common
+    SOURCE_DIR ${PROJECT_SOURCE_DIR}/sae_common
+  )
+
+  FetchContent_MakeAvailable(libcarma_sae_common)
 endif()
 
 if(libcarma_sae_j2735_BUILD_LIBRARY)
-  libcarma_add_to_build(sae_j2735)
+  FetchContent_Declare(libcarma_sae_j2735
+    SOURCE_DIR ${PROJECT_SOURCE_DIR}/sae_j2735
+  )
+
+  FetchContent_MakeAvailable(libcarma_sae_j2735)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,25 +36,13 @@ file(TOUCH ${PROJECT_BINARY_DIR}/COLCON_IGNORE)
 include(FetchContent)
 
 if(libcarma_metaprogramming_BUILD_LIBRARY)
-  FetchContent_Declare(libcarma_metaprogramming
-    SOURCE_DIR ${PROJECT_SOURCE_DIR}/metaprogramming
-  )
-
-  FetchContent_MakeAvailable(libcarma_metaprogramming)
+  libcarma_add_to_build(libcarma_metaprogramming)
 endif()
 
 if(libcarma_sae_common_BUILD_LIBRARY)
-  FetchContent_Declare(libcarma_sae_common
-    SOURCE_DIR ${PROJECT_SOURCE_DIR}/sae_common
-  )
-
-  FetchContent_MakeAvailable(libcarma_sae_common)
+  libcarma_add_to_build(libcarma_sae_common)
 endif()
 
 if(libcarma_sae_j2735_BUILD_LIBRARY)
-  FetchContent_Declare(libcarma_sae_j2735
-    SOURCE_DIR ${PROJECT_SOURCE_DIR}/sae_j2735
-  )
-
-  FetchContent_MakeAvailable(libcarma_sae_j2735)
+  libcarma_add_to_build(libcarma_sae_j2735)
 endif()

--- a/cmake/libcarma_add_to_build.cmake
+++ b/cmake/libcarma_add_to_build.cmake
@@ -16,41 +16,49 @@
 libcarma_add_to_build
 ---------------------
 
-This module defines a function to conditionally add a subdirectory to the build
-tree. Some CARMA Library libraries depend on others, but attempting to add
-their subdirectories to the build tree will cause configuration errors if their
-contained targets have already been added. Conditionally adding the
-subdirectory avoids this issue.
+This module defines a function to add a CARMA Library to the build tree. Some
+CARMA libraries may be built as standalone libraries while also being included
+as dependencies for  other CARMA libraries simultanesouly being built. Using
+the add_subdirectory() function can lead to issues in this case because the
+contained targets would be defined multiple times. Instead, we can use
+``FetchContent``, which provides the end-results we are looking for but without
+the management headache.
 
 .. command:: libcarma_add_to_build
 
-  Add subdirectory to build if its contained targets have not already been
-  added to the build tree:
+  Add specified CARMA Library package's directory to the buld tree using
+  ``FetchContent``:
   functions::
 
-    libcarma_add_to_build(target)
+    libcarma_add_to_build(package)
 
-  ``libcarma_add_to_build()`` adds the specified target's containing
-  subdirectory to the build tree if the target has not already been added. Note
+  ``libcarma_add_to_build()`` adds the specified CARMA Library package's
+  containing subdirectory to the build tree using ``FetchContent``. Note
   that this function makes several implicit assumptions:
 
-    1. Argument ``target`` uses the naming convention ``libcarma::<library>``,
+    1. Argument ``package`` uses the naming convention ``libcarma_<library>``,
        where ``<library>`` is the name of the CARMA Library library of interest.
     2. The containing subdirectory of ``<library>`` uses the name ``<library>``.
 
   The options are:
 
-  ``target``
-    Specifies the target name that will be checked.
+  ``package``
+    Specifies the CARMA Library package name that will be added. The name
+    specified in this option is the same name that would be used in a
+    ``find_pacakge()`` call.
 
 #]=======================================================================]
 
-function(libcarma_add_to_build target)
+include(FetchContent)
 
-  string(REPLACE "libcarma::" "" target_no_namespace ${target})
+function(libcarma_add_to_build package)
 
-  if(NOT TARGET ${target})
-    add_subdirectory(${target_no_namespace})
-  endif()
+  string(REPLACE "libcarma_" "" package_no_prefix ${package})
+
+  FetchContent_Declare(${package}
+    SOURCE_DIR ${PROJECT_SOURCE_DIR}/${package_no_prefix}
+  )
+
+  FetchContent_MakeAvailable(${package})
 
 endfunction()

--- a/sae_common/dependencies.cmake
+++ b/sae_common/dependencies.cmake
@@ -1,7 +1,1 @@
-include(FetchContent)
-
-FetchContent_Declare(libcarma_metaprogramming
-  SOURCE_DIR ${PROJECT_SOURCE_DIR}/metaprogramming
-)
-
-FetchContent_MakeAvailable(libcarma_metaprogramming)
+libcarma_add_to_build(libcarma_metaprogramming)

--- a/sae_common/dependencies.cmake
+++ b/sae_common/dependencies.cmake
@@ -1,1 +1,7 @@
-libcarma_add_to_build(libcarma::metaprogramming)
+include(FetchContent)
+
+FetchContent_Declare(libcarma_metaprogramming
+  SOURCE_DIR ${PROJECT_SOURCE_DIR}/metaprogramming
+)
+
+FetchContent_MakeAvailable(libcarma_metaprogramming)

--- a/sae_j2735/dependencies.cmake
+++ b/sae_j2735/dependencies.cmake
@@ -10,4 +10,10 @@ CPMAddPackage(NAME units
   "BUILD_DOCS OFF"
 )
 
-libcarma_add_to_build(libcarma::sae_common)
+include(FetchContent)
+
+FetchContent_Declare(libcarma_sae_common
+  SOURCE_DIR ${PROJECT_SOURCE_DIR}/sae_common
+)
+
+FetchContent_MakeAvailable(libcarma_sae_common)

--- a/sae_j2735/dependencies.cmake
+++ b/sae_j2735/dependencies.cmake
@@ -10,10 +10,4 @@ CPMAddPackage(NAME units
   "BUILD_DOCS OFF"
 )
 
-include(FetchContent)
-
-FetchContent_Declare(libcarma_sae_common
-  SOURCE_DIR ${PROJECT_SOURCE_DIR}/sae_common
-)
-
-FetchContent_MakeAvailable(libcarma_sae_common)
+libcarma_add_to_build(libcarma_sae_common)


### PR DESCRIPTION
The `libcarma_add_to_build()` function now uses `FetchContent` because it can handle the scenario when a CARMA library is built by itself and also as a dependency for another CARMA library.

Closes #21 