### PR TITLE
Add CMake macro to run clang-tidy

### DIFF
--- a/cmake/libcarma_run_clang_tidy_with_build.cmake
+++ b/cmake/libcarma_run_clang_tidy_with_build.cmake
@@ -1,0 +1,65 @@
+# Copyright 2023 Adam Morrissett
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#[=======================================================================[.rst:
+libcarma_run_clang_tidy_with_build
+----------------------------------
+
+This module defines a macro that enables runing clang-tidy for each target
+built by the CMake project. Running clang-tidy alongside the CMake build makes
+it easier for develoers to run static analysis on their code. Instead of
+invoking clang-tidy manually, it gets run automatically.
+
+.. command:: libcarma_run_clang_tidy_with_build
+
+  Enable and run clang-tidy for each CMake target added after this macro is
+  called:
+  functions::
+
+    libcarma_run_clang_tidy_with_build()
+
+  ``libcarma_run_clang_tidy_with_build()`` enables running clang-tidy for all
+  targets added after this macro is called. Calling this macro assumes that
+  clang-tidy is installed on the system and is findable with ``find_program()``.
+  If CMake cannot find clang-tidy, it will emit a warning message during
+  project configuration. A .clang-tidy file is assumed to be at the
+  project's root.
+
+#]=======================================================================]
+
+macro(libcarma_run_clang_tidy_with_build)
+
+  find_program(clang_tidy_EXECUTABLE clang-tidy)
+
+  file(RELATIVE_PATH current_directory_name
+    ${PROJECT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+
+  if(clang_tidy_EXECUTABLE)
+    message(STATUS "libcarma ${current_directory_name}: Enabling clang-tidy")
+
+    # CMake does not seem to pass C++ standard to clang-tidy when using GCC.
+    # Related CMake issue: https://gitlab.kitware.com/cmake/cmake/-/issues/24238
+    set(CMAKE_CXX_CLANG_TIDY "${clang_tidy_EXECUTABLE};-extra-arg=-std=c++${CMAKE_CXX_STANDARD}")
+    set(CMAKE_C_CLANG_TIDY ${clang_tidy_EXECUTABLE})
+  else()
+    message(WARNING
+      "libcarma ${current_directory_name}: Could not find clang-tidy "
+      "executable. CMake will continue configuring the project, but it will "
+      "not execute clang-tidy."
+    )
+  endif()
+
+endmacro()

--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -17,6 +17,7 @@ include(libcarma_target_remove_library_prefix)
 include(libcarma_target_remove_export_name_prefix)
 include(libcarma_target_set_compiler_warnings)
 include(libcarma_target_set_install_rules)
+include(libcarma_run_clang_tidy_with_build)
 
 include(${PROJECT_SOURCE_DIR}/dependency_versions.cmake)
 

--- a/metaprogramming/CMakeLists.txt
+++ b/metaprogramming/CMakeLists.txt
@@ -14,6 +14,12 @@
 
 include(options.cmake)
 
+if(libcarma_metaprogramming_RUN_CLANG_TIDY)
+  # Note: this function must be called before any libraries or executables
+  # are added. Otherwise, clang-tidy will not be run on them.
+  libcarma_run_clang_tidy_with_build()
+endif()
+
 add_library(libcarma_metaprogramming INTERFACE)
 add_library(libcarma::metaprogramming ALIAS libcarma_metaprogramming)
 

--- a/metaprogramming/options.cmake
+++ b/metaprogramming/options.cmake
@@ -31,3 +31,8 @@ option(libcarma_metaprogramming_BUILD_PACKAGING
   "Build CARMA Metaprogramming Library packaging artifacts"
   ${libcarma_BUILD_PACKAGING}
 )
+
+option(libcarma_metaprogramming_RUN_CLANG_TIDY
+  "Run clang-tidy when building CARMA Metaprogramming Library"
+  ${libcarma_RUN_CLANG_TIDY}
+)

--- a/options.cmake
+++ b/options.cmake
@@ -43,6 +43,11 @@ option(libcarma_BUILD_PACKAGING
   ${PROJECT_IS_TOP_LEVEL}
 )
 
+option(libcarma_RUN_CLANG_TIDY
+  "Run clang-tidy when building CMake targets"
+  FALSE
+)
+
 # Options to build individual libraries
 option(libcarma_metaprogramming_BUILD_LIBRARY
   "Build CARMA Metaprogramming library"


### PR DESCRIPTION
The macro enables clang-tidy to be run on each target (library or executable) added after its invocation. The project has also been updated with CMake options to enable it project-wide or for specific libraries.

Closes #23 