### PR TITLE
Add static analysis CI

### DIFF
--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -1,0 +1,20 @@
+name: Continuous integration
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  static_analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure CMake (with clang-tidy)
+        run: |
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_COMPILER=clang++-14 \
+            -DCMAKE_C_COMPILER=clang-14 \
+            -Dlibcarma_RUN_CLANG_TIDY \
+            .

--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -10,6 +10,9 @@ jobs:
   static_analysis:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code repository
+        uses: actions/checkout@v4
+
       - name: Configure CMake (with clang-tidy)
         run: |
           cmake -B build \

--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -16,5 +16,5 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_CXX_COMPILER=clang++-14 \
             -DCMAKE_C_COMPILER=clang-14 \
-            -Dlibcarma_RUN_CLANG_TIDY \
+            -Dlibcarma_RUN_CLANG_TIDY=TRUE \
             .


### PR DESCRIPTION
This commit provides the first type of continuous integration configuration for libcarma. It establishes clang-tidy. More CI configs to come.

Closes #27 