### PR TITLE
Add CI config for unit tests

### DIFF
--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -21,3 +21,25 @@ jobs:
             -DCMAKE_C_COMPILER=clang-14 \
             -Dlibcarma_RUN_CLANG_TIDY=TRUE \
             .
+
+  unit_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code repository
+        uses: actions/checkout@v4
+
+      - name: Configure CMake
+        run: |
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_COMPILER=clang++-14 \
+            -DCMAKE_C_COMPILER=clang-14 \
+            .
+
+      - name: Build project
+        run: |
+          cmake --build build
+
+      - name: Run CTest
+        run: |
+          ctest --test-dir build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 # This project uses PROJECT_IS_TOP_LEVEL and C_STANDARD 17, both of which were
-# added in CMake 3.21.
-cmake_minimum_required(VERSION 3.21)
+# added in CMake 3.21. It also uses the SYSTEM keyword for add_subdirectory
+# (through calls to CPMAddPakcage), which was added in CMake 3.25.
+cmake_minimum_required(VERSION 3.25)
 project(libcarma)
 enable_testing()
 

--- a/sae_common/dependencies.cmake
+++ b/sae_common/dependencies.cmake
@@ -1,1 +1,11 @@
+CPMAddPackage(NAME units
+  GITHUB_REPOSITORY nholthaus/units
+  GIT_TAG ${libcarma_nholthaus_units_DEP_VERSION}
+  SYSTEM ON
+  EXCLUDE_FROM_ALL ON
+  OPTIONS
+  "BUILD_TESTS OFF"
+  "BUILD_DOCS OFF"
+)
+
 libcarma_add_to_build(libcarma_metaprogramming)

--- a/sae_j2735/dependencies.cmake
+++ b/sae_j2735/dependencies.cmake
@@ -2,7 +2,7 @@ include(libcarma_add_to_build)
 
 CPMAddPackage(NAME units
   GITHUB_REPOSITORY nholthaus/units
-  GIT_TAG v2.3.3
+  GIT_TAG ${libcarma_nholthaus_units_DEP_VERSION}
   SYSTEM ON
   EXCLUDE_FROM_ALL ON
   OPTIONS


### PR DESCRIPTION
The CI pipeline now builds and runs unit tests for all CARMA Library libraries. The units library dependency uses the top-level dependency version variable. CMake has been updated to require at least 3.25 because of the `add_subdirectory` `SYSTEM` keyword.

Closes #29 