### PR TITLE
Disable compiler extensions for `libcarma`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,10 @@ include(dependencies.cmake)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_C_STANDARD 17)
 
+# Compiler exentions may not be portable to other compilers
+set(CMAKE_CXX_EXTENSIONS FALSE)
+set(CMAKE_C_EXTENSIONS FALSE)
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ${libcarma_EXPORT_COMPILE_COMMANDS})
 
 # This prevents colcon from trying to build CMake build artifacts when the


### PR DESCRIPTION
This PR disables compiler extensions across the project for C and C++ code.

Closes #33 