### PR TITLE
Add Python setup step to Pages workflow

### DIFF
--- a/.github/workflows/github_pages.yaml
+++ b/.github/workflows/github_pages.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build with MkDocs
         run: |
-          python -m pip install -r requirements.txt
+          python -m pip install -r docs/requirements.txt
           mkdocs build
 
       - name: Upload artifact

--- a/.github/workflows/github_pages.yaml
+++ b/.github/workflows/github_pages.yaml
@@ -20,8 +20,12 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v4
 
+      - name: Setup Python
+        uses: actions/setup-python@v4
+
       - name: Build with MkDocs
         run: |
+          python -m pip install -r requirements.txt
           mkdocs build
 
       - name: Upload artifact

--- a/.github/workflows/github_pages.yaml
+++ b/.github/workflows/github_pages.yaml
@@ -21,7 +21,9 @@ jobs:
         uses: actions/configure-pages@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
 
       - name: Build with MkDocs
         run: |


### PR DESCRIPTION
The GitHub Pages workflow previously did not setup Python or install the necessary packages.

Closes #47 