### PR TITLE
Add exception class

### DIFF
--- a/exception/CMakeLists.txt
+++ b/exception/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Copyright 2024 Adam Morrissett
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(options.cmake)
+
+add_library(libcarma_exception INTERFACE)
+add_library(libcarma::exception ALIAS libcarma_exception)
+
+target_include_directories(libcarma_exception
+  INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+)
+
+if(libcarma_exception_BUILD_TESTS)
+  add_subdirectory(test)
+endif()

--- a/exception/include/libcarma/exception/exception.hpp
+++ b/exception/include/libcarma/exception/exception.hpp
@@ -1,0 +1,37 @@
+// Copyright 2024 Adam Morrissett
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBCARMA_EXCEPTION_HPP
+#define LIBCARMA_EXCEPTION_HPP
+
+#include <string>
+#include <utility>
+
+namespace carma::exception
+{
+class Exception
+{
+public:
+  explicit Exception(std::string_view str) : str_{str} {}
+
+  auto what() const noexcept -> std::string const & { return str_; }
+  auto what() -> std::string & { return const_cast<std::string &>(std::as_const(*this).what()); }
+
+private:
+  std::string str_{""};
+};
+
+}  // namespace carma::exception
+
+#endif  // LIBCARMA_EXCEPTION_HPP

--- a/exception/options.cmake
+++ b/exception/options.cmake
@@ -1,0 +1,18 @@
+# Copyright 2024 Adam Morrissett
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+option(libcarma_exception_BUILD_TESTS
+  "Build CARMA Exception tests"
+  ${libcarma_BUILD_TESTS}
+)

--- a/exception/test/CMakeLists.txt
+++ b/exception/test/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Copyright 2024 Adam Morrissett
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_executable(libcarma_exception_unit_tests
+  test_exception.cpp
+)
+
+target_link_libraries(libcarma_exception_unit_tests
+  PRIVATE
+    libcarma::exception
+    GTest::gtest_main
+)
+
+libcarma_target_set_compiler_warnings(libcarma_exception_unit_tests
+  PRIVATE
+  WARNINGS_AS_ERRORS
+)
+
+include(GoogleTest)
+gtest_discover_tests(libcarma_exception_unit_tests)

--- a/exception/test/test_exception.cpp
+++ b/exception/test/test_exception.cpp
@@ -1,0 +1,32 @@
+// Copyright 2024 Adam Morrissett
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <libcarma/exception/exception.hpp>
+
+TEST(TestException, ConstString)
+{
+  carma::exception::Exception const ex{"some string"};
+
+  EXPECT_EQ(ex.what(), "some string");
+}
+
+TEST(TestException, MutableString)
+{
+  carma::exception::Exception ex{"some string"};
+  ASSERT_EQ(ex.what(), "some string");
+
+  ex.what() += " more text";
+  EXPECT_EQ(ex.what(), "some string more text");
+}


### PR DESCRIPTION
This class provides a mutable what() string. The std::runtime_error class, and similar classes, have immutable what() strings. This prevents catching code from adding context as the exception bubbles up the call stack.

Closes #49 