### PR TITLE
Make exception library independent

### DIFF
--- a/exception/cmake/libcarma_exceptionConfig.cmake
+++ b/exception/cmake/libcarma_exceptionConfig.cmake
@@ -11,27 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.25)
-project(libcarma_exception)
 
-include(options.cmake)
-include(dependencies.cmake)
-
-add_library(libcarma_exception INTERFACE)
-add_library(libcarma::exception ALIAS libcarma_exception)
-
-target_include_directories(libcarma_exception
-  INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
-)
-
-if(libcarma_exception_BUILD_TESTS)
-  enable_testing()
-  add_subdirectory(test)
-endif()
-
-if(libcarma_exception_BUILD_INSTALL)
-  include(libcarma_target_set_install_rules)
-
-  libcarma_target_set_install_rules(libcarma_exception)
-endif()
+include(${CMAKE_CURRENT_LIST_DIR}/libcarma/libcarma_exceptionTargets.cmake)

--- a/exception/dependencies.cmake
+++ b/exception/dependencies.cmake
@@ -1,0 +1,5 @@
+find_package(libcarma_cmake REQUIRED)
+
+if(libcarma_exception_BUILD_TESTS)
+  find_package(GTest REQUIRED)
+endif()

--- a/exception/options.cmake
+++ b/exception/options.cmake
@@ -16,3 +16,8 @@ option(libcarma_exception_BUILD_TESTS
   "Build CARMA Exception tests"
   ${libcarma_BUILD_TESTS}
 )
+
+option(libcarma_exception_BUILD_INSTALL
+  "Build CARMA Exception Library CMake install targets"
+  ${libcarma_BUILD_INSTALL}
+)

--- a/exception/test/CMakeLists.txt
+++ b/exception/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include(libcarma_target_set_compiler_warnings)
+
 add_executable(libcarma_exception_unit_tests
   test_exception.cpp
 )


### PR DESCRIPTION
The Exception library is now independent from the top-level CMake project.

Closes #54 