### PR TITLE
Make Metaprogramming library independent

### DIFF
--- a/metaprogramming/CMakeLists.txt
+++ b/metaprogramming/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023 Adam Morrissett
+# Copyright 2024 Adam Morrissett
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+cmake_minimum_required(VERSION 3.25)
+project(libcarma_metaprogramming)
+
 include(options.cmake)
+include(dependencies.cmake)
 
 if(libcarma_metaprogramming_RUN_CLANG_TIDY)
   # Note: this function must be called before any libraries or executables
@@ -29,9 +33,12 @@ target_include_directories(libcarma_metaprogramming
 )
 
 if(libcarma_metaprogramming_BUILD_TESTS)
+  enable_testing()
   add_subdirectory(test)
 endif()
 
 if(libcarma_metaprogramming_BUILD_INSTALL)
+  include(libcarma_target_set_install_rules)
+
   libcarma_target_set_install_rules(libcarma_metaprogramming)
 endif()

--- a/metaprogramming/dependencies.cmake
+++ b/metaprogramming/dependencies.cmake
@@ -1,0 +1,5 @@
+find_package(libcarma_cmake REQUIRED)
+
+if(libcarma_exception_BUILD_TESTS)
+  find_package(GTest REQUIRED)
+endif()

--- a/metaprogramming/test/CMakeLists.txt
+++ b/metaprogramming/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include(libcarma_target_set_compiler_warnings)
+
 add_library(libcarma_metaprogramming_unit_tests
   test_always_false.cpp
 )

--- a/metaprogramming/test/test_always_false.cpp
+++ b/metaprogramming/test/test_always_false.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <libcarma/metaprogramming/always_false.hpp>
+#include <type_traits>
 
 struct T
 {


### PR DESCRIPTION
The library was previously a subdirectory of the top-level CMake project, but now it is independent.

Closes #56 