### PR TITLE
Make SAE Common library independent

### DIFF
--- a/sae_common/CMakeLists.txt
+++ b/sae_common/CMakeLists.txt
@@ -1,3 +1,20 @@
+# Copyright 2024 Adam Morrissett
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.25)
+project(libcarma_sae_common)
+
 include(options.cmake)
 include(dependencies.cmake)
 
@@ -16,9 +33,12 @@ target_link_libraries(libcarma_sae_common
 )
 
 if(libcarma_sae_common_BUILD_TESTS)
+  enable_testing()
   add_subdirectory(test)
 endif()
 
 if(libcarma_sae_common_BUILD_INSTALL)
+  include(libcarma_target_set_install_rules)
+
   libcarma_target_set_install_rules(libcarma_sae_common)
 endif()

--- a/sae_common/cmake/libcarma_sae_commonConfig.cmake
+++ b/sae_common/cmake/libcarma_sae_commonConfig.cmake
@@ -12,10 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_package(libcarma_cmake REQUIRED)
-find_package(libcarma_metaprogramming REQUIRED)
-find_package(units REQUIRED)
-
-if(libcarma_sae_common_BUILD_TESTS)
-  find_package(GTest REQUIRED)
-endif()
+include(${CMAKE_CURRENT_LIST_DIR}/libcarma_sae_commonTargets.cmake)

--- a/sae_common/test/CMakeLists.txt
+++ b/sae_common/test/CMakeLists.txt
@@ -1,3 +1,19 @@
+# Copyright 2024 Adam Morrissett
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(libcarma_target_set_compiler_warnings)
+
 add_executable(libcarma_sae_common_unit_tests
   test_bad_data_element_access.cpp
   test_data_element.cpp


### PR DESCRIPTION
This PR extracts the SAE Common library out of the top-level CMake project.

Closes #57 