### PR TITLE
Make SAE J2735 library independent

### DIFF
--- a/sae_j2735/CMakeLists.txt
+++ b/sae_j2735/CMakeLists.txt
@@ -1,3 +1,20 @@
+# Copyright 2024 Adam Morrissett
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.25)
+project(libcarma_sae_j2735)
+
 include(options.cmake)
 include(dependencies.cmake)
 
@@ -16,9 +33,12 @@ target_link_libraries(libcarma_sae_j2735
 )
 
 if(libcarma_sae_j2735_BUILD_TESTS)
+  enable_testing()
   add_subdirectory(test)
 endif()
 
 if(libcarma_sae_j2735_BUILD_INSTALL)
+  include(libcarma_target_set_install_rules)
+
   libcarma_target_set_install_rules(libcarma_sae_j2735)
 endif()

--- a/sae_j2735/cmake/libcarma_sae_j2735Config.cmake
+++ b/sae_j2735/cmake/libcarma_sae_j2735Config.cmake
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_package(libcarma_cmake REQUIRED)
-find_package(libcarma_sae_common REQUIRED)
-find_package(units REQUIRED)
+include(CMakeFindDependencyMacro)
 
-if(libcarma_sae_j2735_BUILD_TESTS)
-  find_package(GTest REQUIRED)
-endif()
+find_dependency(libcarma_sae_common)
+
+include(${CMAKE_CURRENT_LIST_DIR}/libcarma_sae_j2735Targets.cmake)

--- a/sae_j2735/test/CMakeLists.txt
+++ b/sae_j2735/test/CMakeLists.txt
@@ -1,3 +1,19 @@
+# Copyright 2024 Adam Morrissett
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(libcarma_target_set_compiler_warnings)
+
 add_executable(libcarma_sae_j2735_tests
   test_angle.cpp
 )
@@ -6,6 +22,11 @@ target_link_libraries(libcarma_sae_j2735_tests
   PRIVATE
     GTest::gtest_main
     libcarma::sae_j2735
+)
+
+libcarma_target_set_compiler_warnings(libcarma_sae_j2735_tests
+  PRIVATE
+  WARNINGS_AS_ERRORS
 )
 
 include(GoogleTest)


### PR DESCRIPTION
The library is no longer a subdirectory under the top-level CMake project. It is fully independent.

Closes #58 