### PR TITLE
Fix Config.cmake include paths

### DIFF
--- a/exception/cmake/libcarma_exceptionConfig.cmake
+++ b/exception/cmake/libcarma_exceptionConfig.cmake
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(${CMAKE_CURRENT_LIST_DIR}/libcarma/libcarma_exceptionTargets.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/libcarma_exceptionTargets.cmake)

--- a/metaprogramming/cmake/libcarma_metaprogrammingConfig.cmake
+++ b/metaprogramming/cmake/libcarma_metaprogrammingConfig.cmake
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(${CMAKE_CURRENT_LIST_DIR}/libcarma/libcarma_metaprogrammingTargets.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/libcarma_metaprogrammingTargets.cmake)


### PR DESCRIPTION
Remove unnecessary `libcarma` subdirectory.

Closes #64 