### PR TITLE
Fix dependency declarations

### DIFF
--- a/sae_common/cmake/libcarma_sae_commonConfig.cmake
+++ b/sae_common/cmake/libcarma_sae_commonConfig.cmake
@@ -12,4 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include(CMakeFindDependencyMacro)
+
+find_dependency(libcarma_metaprogramming)
+find_dependency(units)
+
 include(${CMAKE_CURRENT_LIST_DIR}/libcarma_sae_commonTargets.cmake)

--- a/sae_j2735/cmake/libcarma_sae_j2735Config.cmake
+++ b/sae_j2735/cmake/libcarma_sae_j2735Config.cmake
@@ -15,5 +15,6 @@
 include(CMakeFindDependencyMacro)
 
 find_dependency(libcarma_sae_common)
+find_dependency(units)
 
 include(${CMAKE_CURRENT_LIST_DIR}/libcarma_sae_j2735Targets.cmake)


### PR DESCRIPTION
The SAE Common and SAE J2735 libraries did not declare their dependencies in their Config.cmake files

Closes #66 